### PR TITLE
カスタムしたパレットの背景色と文字色が効くようにスタイルを書き出しします

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -28,3 +28,13 @@
   --_lighter-color-gray: #{color.scale(map.get($theme-colors, gray01), $lightness: 50%)}; 
   --_lightest-color-gray: #{color.scale(map.get($theme-colors, gray01), $lightness: 80%)};
 }
+
+// 文字色と背景色を書き出し
+@each $key, $color-var in $theme-colors {
+  .has-#{$key}-color {
+    color: var(--color-#{$key});
+  }
+  .has-#{$key}-background-color {
+    background-color: var(--color-#{$key});
+  }
+}


### PR DESCRIPTION
カスタムしたカラーパレットの色の背景色と文字色のクラスの書き出しを忘れていたので追加します